### PR TITLE
Simplify axis calibration UX with sequential flow and bug fixes

### DIFF
--- a/UnPlotter.html
+++ b/UnPlotter.html
@@ -138,21 +138,24 @@
                     <!-- Calibration Section -->
                     <div class="calibration-section" id="calibrationSection" style="display: none;">
                         <h3>Axis Calibration</h3>
-                        <p class="calibration-instruction">Select a line segment for each axis and enter its min/max values in data coordinates.</p>
+
+                        <div class="calibration-start">
+                            <button id="startCalibration" class="btn btn-primary">Start Calibration</button>
+                            <span id="calibrationPrompt" class="calibration-prompt"></span>
+                        </div>
 
                         <div class="calibration-grid">
                             <div class="axis-calibration">
                                 <div class="calibration-points">
                                     <div class="point-input">
                                         <h4>X</h4>
-                                        <button id="selectXAxis" class="btn btn-calibrate">Select</button>
+                                        <span id="xAxisStatus" class="status-indicator">○</span>
                                         <input type="number" id="xMinValue" placeholder="X Min" step="any">
                                         <input type="number" id="xMaxValue" placeholder="X Max" step="any">
                                         <label style="margin-left: 0.75rem;">
                                             <input type="checkbox" id="xLogScale">
                                             log
                                         </label>
-                                        <span id="xAxisStatus" class="status-indicator">○</span>
                                     </div>
                                 </div>
                             </div>
@@ -161,14 +164,13 @@
                                 <div class="calibration-points">
                                     <div class="point-input">
                                         <h4>Y</h4>
-                                        <button id="selectYAxis" class="btn btn-calibrate">Select</button>
+                                        <span id="yAxisStatus" class="status-indicator">○</span>
                                         <input type="number" id="yMinValue" placeholder="Y Min" step="any">
                                         <input type="number" id="yMaxValue" placeholder="Y Max" step="any">
                                         <label>
                                             <input type="checkbox" id="yLogScale">
                                             log
                                         </label>
-                                        <span id="yAxisStatus" class="status-indicator">○</span>
                                     </div>
                                 </div>
                             </div>

--- a/src/axis-calibrator.js
+++ b/src/axis-calibrator.js
@@ -139,10 +139,15 @@ export class AxisCalibrator {
         const axisKey = axis === 'x' ? 'xAxis' : 'yAxis';
         const segment = this.calibrationSegments[axisKey];
         const values = this.calibrationValues[axisKey];
-        
-        return segment !== null && 
-               values.min !== null && 
+
+        return segment !== null &&
+               values.min !== null &&
                values.max !== null;
+    }
+
+    hasSegment(axis) {
+        const axisKey = axis === 'x' ? 'xAxis' : 'yAxis';
+        return this.calibrationSegments[axisKey] !== null;
     }
 
     checkIfFullyCalibrated() {

--- a/src/axis-calibrator.js
+++ b/src/axis-calibrator.js
@@ -86,7 +86,7 @@ export class AxisCalibrator {
 
     setCalibrationSegment(axis, segment) {
         const axisKey = axis === 'x' ? 'xAxis' : 'yAxis';
-        
+
         // If segment is actually a curve with points array, store original points (PDF coords)
         if (segment.points && segment.points.length > 0) {
             this.calibrationCurves[axisKey] = segment.points;
@@ -96,9 +96,10 @@ export class AxisCalibrator {
             this.calibrationCurves[axisKey] = null;
             this.calibrationSegments[axisKey] = segment;
         }
-        
+
         console.log(`Set ${axis}-axis segment:`, this.calibrationSegments[axisKey]);
-        
+
+        this.checkIfFullyCalibrated();
         return this.isAxisCalibrated(axis);
     }
     

--- a/src/canvas-overlay.js
+++ b/src/canvas-overlay.js
@@ -105,7 +105,7 @@ export class CanvasOverlay {
         this.overlayCanvas.style.pointerEvents = enabled ? 'auto' : 'none';
 
         if (enabled) {
-            this.drawAllCurves();
+            this.redraw();
         } else {
             this.clear();
         }
@@ -116,7 +116,7 @@ export class CanvasOverlay {
         this.overlayCanvas.style.pointerEvents = enabled ? 'auto' : 'none';
 
         if (enabled) {
-            this.drawAllCurves();
+            this.redraw();
         } else {
             this.clear();
         }

--- a/src/main.js
+++ b/src/main.js
@@ -366,25 +366,31 @@ class UnPlotApp {
             // Auto-advance from X to Y axis
             if (axis === 'x' && !this.axisCalibrator.hasSegment('y')) {
                 this.pendingCalibration = { axis: 'y' };
+                this.axisCalibrator.startCalibration('y');
                 this.showCalibrationPrompt('Now click a line for the Y-axis');
-                // Stay in calibration mode with crosshair cursor
                 this.checkCalibrationComplete();
                 return;
             }
 
-            // Exit calibration mode after Y-axis (or if Y was already set)
+            // Exit calibration mode
             this.calibrationMode = false;
             this.pendingCalibration = null;
             this.canvas.style.cursor = 'default';
-            this.hideCalibrationPrompt();
+
+            // Show prompt only if values still needed, otherwise hide it
+            if (axis === 'y' && !this.axisCalibrator.isCalibrated) {
+                this.showCalibrationPrompt('Now enter min/max values for each axis');
+            } else {
+                this.hideCalibrationPrompt();
+            }
+
+            this.checkCalibrationComplete();
 
             if (this.selectionMode) {
                 this.canvasOverlay.enableSelectionMode(true);
             } else {
                 this.canvasOverlay.enableSelectionMode(false);
             }
-
-            this.checkCalibrationComplete();
         } else {
             this.selectedCurveForLabeling = detail.curve;
             console.log(`Selected curve with ${detail.curve.points.length} points - enter a label to save it`);
@@ -630,7 +636,7 @@ class UnPlotApp {
 
         if (status.isCalibrated) {
             this.calibrationStatus.innerHTML = '<span class="status-text success">✅ Calibration Complete!</span>';
-            console.log('Calibration complete! You can now export data.');
+            this.hideCalibrationPrompt();
 
             this.exportSection.style.display = 'block';
             this.updateExportPreview();

--- a/src/main.js
+++ b/src/main.js
@@ -419,8 +419,9 @@ class UnPlotApp {
         this.updateCurveBrowser();
         this.updateExportPreview();
 
-        // Show calibration section when first curve is labeled
-        if (this.labeledCurves.length > 0) {
+        // Show export section if calibration is complete and we have curves
+        if (this.labeledCurves.length > 0 && this.axisCalibrator.isCalibrated) {
+            this.exportSection.style.display = 'block';
         }
     }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -463,6 +463,20 @@ header h1 {
     font-size: 0.9rem;
 }
 
+.calibration-start {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.calibration-prompt {
+    color: #ff9800;
+    font-weight: 500;
+    font-style: italic;
+    font-size: 0.9rem;
+}
+
 .calibration-grid {
     display: flex;
     flex-direction: column;

--- a/styles/main.css
+++ b/styles/main.css
@@ -474,7 +474,7 @@ header h1 {
     color: #ff9800;
     font-weight: 500;
     font-style: italic;
-    font-size: 0.9rem;
+    font-size: 1.1rem;
 }
 
 .calibration-grid {


### PR DESCRIPTION
## Summary
Replace separate X/Y axis "Select" buttons with a single "Start Calibration" button that guides users through selecting X-axis → Y-axis → entering values, with real-time guidance prompts at each step. Also fixes several bugs related to calibration state and UI updates.

## Changes

**UX Improvements:**
- New sequential calibration flow: click "Start Calibration" → select X-axis line → automatically prompted to select Y-axis line → enter min/max values
- Added prominent orange guidance text that updates at each step (e.g., "Click a line representing the X-axis", "Now enter min/max values for each axis")
- Moved status indicators (○/●) to be next to axis labels for better visibility

**Bug Fixes:**
- Fix `isCalibrated` flag not updating when calibration segments are set after values were already entered
- Fix canvas overlay not showing selection highlight after clicking a curve
- Fix export button not appearing after clearing labeled curves and adding new ones