### PR TITLE
Fix render failure on PDFs with embedded raster images

### DIFF
--- a/src/path-extractor.js
+++ b/src/path-extractor.js
@@ -558,7 +558,7 @@ export class PathExtractor {
     }
 
     getOperationName(fn) {
-        const OPS = window.pdfjsLib.OPS;
+        const OPS = this.pdfLoader.OPS;
         const opNames = {
             [OPS.stroke]: 'stroke',
             [OPS.fill]: 'fill',

--- a/src/pdf-loader.js
+++ b/src/pdf-loader.js
@@ -17,8 +17,11 @@ export class PDFLoader {
 
     async initPDFJS() {
         try {
-            // Import PDF.js from CDN using ES modules
-            this.pdfjsLib = await import('https://cdn.jsdelivr.net/npm/pdfjs-dist@4.10.38/+esm');
+            // Import PDF.js from CDN using ES modules.
+            // Use the official ESM build directly — the jsdelivr "+esm" re-bundle
+            // injects a `process` shim that makes PDF.js think it is running in
+            // Node.js, which breaks canvas creation for PDFs with embedded images.
+            this.pdfjsLib = await import('https://cdn.jsdelivr.net/npm/pdfjs-dist@4.10.38/build/pdf.min.mjs');
             
             // Configure the worker
             this.pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.10.38/build/pdf.worker.min.mjs';


### PR DESCRIPTION
PDFs containing raster images (e.g. logos in datasheets) fail to render — blank canvas, console shows `TypeError: ...getBuiltinModule is not a function` inside `paintImageXObject`.

**Cause:** the jsdelivr `+esm` re-bundle of pdfjs-dist injects a `process` shim, so PDF.js misdetects the browser as Node.js (see the bogus `Please use the legacy build in Node.js environments` warning on every load) and takes a Node-only canvas path when painting images. Pure-vector PDFs never hit that path, which is why most files worked.

**Fix:** import the official ESM build (`build/pdf.min.mjs`) directly instead of `+esm`. Also switched `getOperationName` to use the loader's `OPS` instead of `window.pdfjsLib`, which only exists as a webpack side effect.
